### PR TITLE
Topic async storage

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -42,5 +42,10 @@
     "<all_urls>",
     "storage",
     "unlimitedStorage"
-  ]
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{e22ef003-e424-45f0-9da1-b0b93617ce49}"
+    }
+  }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -11,43 +11,42 @@ const MINUTE = 60 * 1000
 
 initErrorHandler()
 
-createBackgroundStore().then(store => {
-  // Close the sidebar when the popup is triggered.
-  // In order to receive events here, you need to not have a popup, and you need to trigger
-  // open/close events on sidebarAction and browserAction from a direct user event.
-  browser.browserAction.onClicked.addListener(() => {
-    const state = store.getState()
-    const viewMode = options.selectors.getViewMode(state)
+const store = createBackgroundStore()
+// Close the sidebar when the popup is triggered.
+// In order to receive events here, you need to not have a popup, and you need to trigger
+// open/close events on sidebarAction and browserAction from a direct user event.
+browser.browserAction.onClicked.addListener(() => {
+  const state = store.getState()
+  const viewMode = options.selectors.getViewMode(state)
 
-    if (viewMode === 'sidebar') {
-      browser.sidebarAction.open()
-    } else {
-      browser.sidebarAction.close()
-      browser.browserAction.setPopup({popup: "popup.html"})
-      browser.browserAction.openPopup()
-      browser.browserAction.setPopup({popup: ""})
-    }
-  })
-
-  // Track when tabs change
-  browser.tabs.onActivated.addListener(tabInfo => store.dispatch(changeTab(tabInfo.tabId)))
-  browser.tabs.onUpdated.addListener(tabId => store.dispatch(changeTab(tabId)))
-  browser.tabs.onRemoved.addListener(tabId => store.dispatch(forgetFeeds(tabId)))
-
-  onPopupStateChange(store, (state => {
-    if (state.isUnread) {
-      browser.browserAction.setIcon({path: "images/Brook-Notifications.svg"})
-    } else if (state.canSubscribe) {
-      browser.browserAction.setIcon({path: "images/Brook-Subscribe.svg"})
-    } else {
-      browser.browserAction.setIcon({path: "images/Brook.svg"})
-    }
-  }))
-
-  // Schedule fetching feeds every 15m
-  setInterval(() => {
-    if (navigator.onLine) {
-      store.dispatch(fetchAll())
-    }
-  }, 15 * MINUTE)
+  if (viewMode === 'sidebar') {
+    browser.sidebarAction.open()
+  } else {
+    browser.sidebarAction.close()
+    browser.browserAction.setPopup({popup: "popup.html"})
+    browser.browserAction.openPopup()
+    browser.browserAction.setPopup({popup: ""})
+  }
 })
+
+// Track when tabs change
+browser.tabs.onActivated.addListener(tabInfo => store.dispatch(changeTab(tabInfo.tabId)))
+browser.tabs.onUpdated.addListener(tabId => store.dispatch(changeTab(tabId)))
+browser.tabs.onRemoved.addListener(tabId => store.dispatch(forgetFeeds(tabId)))
+
+onPopupStateChange(store, (state => {
+  if (state.isUnread) {
+    browser.browserAction.setIcon({path: "images/Brook-Notifications.svg"})
+  } else if (state.canSubscribe) {
+    browser.browserAction.setIcon({path: "images/Brook-Subscribe.svg"})
+  } else {
+    browser.browserAction.setIcon({path: "images/Brook.svg"})
+  }
+}))
+
+// Schedule fetching feeds every 15m
+setInterval(() => {
+  if (navigator.onLine) {
+    store.dispatch(fetchAll())
+  }
+}, 15 * MINUTE)

--- a/src/redux/reset.js
+++ b/src/redux/reset.js
@@ -6,10 +6,10 @@ export function resetData() {
   }
 }
 
-export function resetableReducer(reducer) {
+export function resetableReducer(reducer, initialState={}) {
   return (state, action) => {  
     if (action.type === RESET_DATA) {
-      state = undefined
+      state = initialState
     }
     
     return reducer(state, action)


### PR DESCRIPTION
There has been a long standing bug where Brook would often fail to load when the browser launched because the background store would initialize after the proxy stores.  This caused webext-redux's synchronization mechanism to fail until the sidebar was reopened.

Now ONLY the persisted data is loaded asynchronously.